### PR TITLE
Implement cipher tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 Cargo.lock
 *.out
 /docker
+temp

--- a/all_cipher_cases.json
+++ b/all_cipher_cases.json
@@ -1,0 +1,942 @@
+{
+    "cases" : [
+      {
+          "name" : "Connect-Compatible_Ciphers_1",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 772,
+              "cipher" : "TLS_AES_128_GCM_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 772,
+              "cipher" : "TLS_AES_128_GCM_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_2",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 772,
+              "cipher" : "TLS_CHACHA20_POLY1305_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 772,
+              "cipher" : "TLS_CHACHA20_POLY1305_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_3",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 772,
+              "cipher" : "TLS_AES_256_GCM_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 772,
+              "cipher" : "TLS_AES_256_GCM_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_4",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_5",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_6",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_7",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_8",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_9",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_10",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_11",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_12",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_13",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_14",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_15",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_16",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_17",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_18",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_19",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_20",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_21",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_RC4_128_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_RC4_128_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_22",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_23",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_24",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_25",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_26",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_27",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_28",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_29",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_30",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_31",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_32",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_33",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_34",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_35",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_AES_256_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_36",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_37",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_38",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_39",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_40",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_41",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_RC4_128_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_RC4_128_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_42",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_43",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_44",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_45",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_AES_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_46",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_47",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_48",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_RC4_128_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_RC4_128_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_49",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_RC4_128_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_RC4_128_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_50",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_128_GCM_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_128_GCM_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_51",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_256_GCM_SHA384"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_256_GCM_SHA384"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_52",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_53",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_128_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_128_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_54",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_CAMELLIA_128_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_CAMELLIA_128_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_55",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_56",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_256_CBC_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_AES_256_CBC_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_57",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_CAMELLIA_256_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_CAMELLIA_256_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_58",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_SEED_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_SEED_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_59",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_60",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_RC4_128_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_RC4_128_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_61",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_RC4_128_MD5"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_RC4_128_MD5"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_62",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_DES_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_RSA_WITH_DES_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_63",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_DES_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_DHE_DSS_WITH_DES_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_64",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_DES_CBC_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_DES_CBC_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_65",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_66",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_NULL_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDHE_RSA_WITH_NULL_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_67",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_NULL_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_RSA_WITH_NULL_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_68",
+          "server_key" : "ecdsa_p521",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_NULL_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_ECDH_ECDSA_WITH_NULL_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_69",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_NULL_SHA"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_NULL_SHA"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_70",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_NULL_SHA256"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_NULL_SHA256"
+          }
+      },
+      {
+          "name" : "Connect-Compatible_Ciphers_71",
+          "client" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_NULL_MD5"
+          },
+          "server" : {
+              "min_version" : 770,
+              "max_version" : 771,
+              "cipher" : "TLS_RSA_WITH_NULL_MD5"
+          }
+      }
+    ]
+}

--- a/all_cipher_cases.json
+++ b/all_cipher_cases.json
@@ -41,7 +41,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_4",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -68,7 +68,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_6",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -95,7 +95,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_8",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -122,7 +122,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_10",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -136,7 +136,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_11",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -163,7 +163,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_13",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -203,7 +203,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_16",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -230,7 +230,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_18",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -257,7 +257,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_20",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -544,7 +544,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_42",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -571,7 +571,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_44",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -598,7 +598,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_46",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -625,7 +625,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_48",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -847,7 +847,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_65",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,
@@ -887,7 +887,7 @@
       },
       {
           "name" : "Connect-Compatible_Ciphers_68",
-          "server_key" : "ecdsa_p521",
+          "server_key" : "ecdsa_p256",
           "client" : {
               "min_version" : 770,
               "max_version" : 771,

--- a/cases.json
+++ b/cases.json
@@ -28,38 +28,65 @@
             "client" : {
                 "min_version" : 770,
                 "max_version" : 772,
-                "cipher" : "+TLS_AES_128_GCM_SHA256"
+                "cipher" : "TLS_AES_128_GCM_SHA256"
             },
             "server" : {
                 "min_version" : 770,
                 "max_version" : 772,
-                "cipher" : "+TLS_AES_128_GCM_SHA256"
-            }
-        },
-        {
-            "name" : "Connect-Compatible_Ciphers_2",
-            "client" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            },
-            "server" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+                "cipher" : "TLS_AES_128_GCM_SHA256"
             }
         },
         {
             "name" : "Connect-Compatible_Ciphers_3",
             "client" : {
                 "min_version" : 770,
+                "max_version" : 772,
+                "cipher" : "TLS_AES_256_GCM_SHA384"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 772,
+                "cipher" : "TLS_AES_256_GCM_SHA384"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_4",
+            "server_key" : "ecdsa_p521",
+            "client" : {
+                "min_version" : 770,
                 "max_version" : 771,
-                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
             },
             "server" : {
                 "min_version" : 770,
                 "max_version" : 771,
-                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_5",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_9",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
             }
         }
     ]

--- a/cases.json
+++ b/cases.json
@@ -51,7 +51,7 @@
         },
         {
             "name" : "Connect-Compatible_Ciphers_4",
-            "server_key" : "ecdsa_p521",
+            "server_key" : "ecdsa_p256",
             "client" : {
                 "min_version" : 770,
                 "max_version" : 771,

--- a/cases.json
+++ b/cases.json
@@ -77,6 +77,20 @@
             }
         },
         {
+            "name" : "Connect-Compatible_Ciphers_8",
+            "server_key" : "ecdsa_p256",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+            }
+        },
+        {
             "name" : "Connect-Compatible_Ciphers_9",
             "client" : {
                 "min_version" : 770,

--- a/cases.json
+++ b/cases.json
@@ -28,12 +28,12 @@
             "client" : {
                 "min_version" : 770,
                 "max_version" : 772,
-                "ciphers" : "TLS_AES_128_GCM_SHA256"
+                "cipher" : "+TLS_AES_128_GCM_SHA256"
             },
             "server" : {
                 "min_version" : 770,
                 "max_version" : 772,
-                "ciphers" : "TLS_AES_128_GCM_SHA256"
+                "cipher" : "+TLS_AES_128_GCM_SHA256"
             }
         },
         {
@@ -41,66 +41,26 @@
             "client" : {
                 "min_version" : 770,
                 "max_version" : 771,
-                "ciphers" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
             },
             "server" : {
                 "min_version" : 770,
                 "max_version" : 771,
-                "ciphers" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
             }
         },
         {
             "name" : "Connect-Compatible_Ciphers_3",
             "client" : {
                 "min_version" : 770,
-                "max_version" : 770,
-                "ciphers" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+                "max_version" : 771,
+                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
             },
             "server" : {
                 "min_version" : 770,
-                "max_version" : 770,
-                "ciphers" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+                "max_version" : 771,
+                "cipher" : "+TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
             }
-        },
-        {
-            "name" : "Connect-Compatible_Ciphers_4",
-            "client" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            },
-            "server" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            }
-        },
-        {
-            "name" : "Connect-Compatible_Ciphers_5",
-            "client" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            },
-            "server" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            }
-        },
-        {
-            "name" : "Connect-Incompatible_Ciphers",
-            "client" : {
-                "min_version" : 770,
-                "max_version" : 772,
-                "ciphers" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
-            },
-            "server" : {
-                "min_version" : 770,
-                "max_version" : 772,
-                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            },
-            "should-fail" : true
         }
     ]
 }

--- a/cases.json
+++ b/cases.json
@@ -22,6 +22,85 @@
                 "min_version" : 770,
                 "max_version" : 772
             }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_1",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 772,
+                "ciphers" : "TLS_AES_128_GCM_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 772,
+                "ciphers" : "TLS_AES_128_GCM_SHA256"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_2",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "ciphers" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "ciphers" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_3",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 770,
+                "ciphers" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 770,
+                "ciphers" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_4",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_5",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            }
+        },
+        {
+            "name" : "Connect-Incompatible_Ciphers",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 772,
+                "ciphers" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 772,
+                "ciphers" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            },
+            "should-fail" : true
         }
     ]
 }

--- a/fail.json
+++ b/fail.json
@@ -11,45 +11,5 @@
                 "max_version" : 771
             }
         }
-        {
-            "name" : "Connect-Compatible_Ciphers_2",
-            "client" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "cipher" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
-            },
-            "server" : {
-                "min_version" : 770,
-                "max_version" : 771,
-                "cipher" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
-            }
-        },
-        {
-            "name" : "Connect-Compatible_Ciphers_3",
-            "client" : {
-                "min_version" : 770,
-                "max_version" : 770,
-                "cipher" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
-            },
-            "server" : {
-                "min_version" : 770,
-                "max_version" : 770,
-                "cipher" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
-            }
-        },
-        {
-            "name" : "Connect-Incompatible_Ciphers",
-            "client" : {
-                "min_version" : 770,
-                "max_version" : 772,
-                "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
-            },
-            "server" : {
-                "min_version" : 770,
-                "max_version" : 772,
-                "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            },
-            "should-fail" : true
-        }
     ]
 }

--- a/fail.json
+++ b/fail.json
@@ -11,5 +11,45 @@
                 "max_version" : 771
             }
         }
+        {
+            "name" : "Connect-Compatible_Ciphers_2",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 771,
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+            }
+        },
+        {
+            "name" : "Connect-Compatible_Ciphers_3",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 770,
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 770,
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_NULL_SHA"
+            }
+        },
+        {
+            "name" : "Connect-Incompatible_Ciphers",
+            "client" : {
+                "min_version" : 770,
+                "max_version" : 772,
+                "cipher" : "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+            },
+            "server" : {
+                "min_version" : 770,
+                "max_version" : 772,
+                "cipher" : "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            },
+            "should-fail" : true
+        }
     ]
 }

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+BASE_DIR=$(pwd)
+CASE_FILE=$2
+#export RUST_LOG=debug
+
+run_boring_server() {
+  cargo run -- \
+  --client $BASE_DIR/../dist/Debug/bin/nss_bogo_shim \
+  --server $BASE_DIR/../boringssl/build/ssl/test/bssl_shim \
+  --rootdir $BASE_DIR/../boringssl/ssl/test/runner/ \
+  --test-cases $BASE_DIR/$CASE_FILE \
+  --client-writes-first
+}
+
+run_boring_client() {
+  cargo run -- \
+  --client $BASE_DIR/../boringssl/build/ssl/test/bssl_shim \
+  --server $BASE_DIR/../dist/Debug/bin/nss_bogo_shim \
+  --rootdir $BASE_DIR/../boringssl/ssl/test/runner/ \
+  --test-cases $BASE_DIR/$CASE_FILE
+}
+
+run_ossl_server() {
+  cargo run -- \
+  --client $BASE_DIR/../dist/Debug/bin/nss_bogo_shim \
+  --server $BASE_DIR/../openssl/test/ossl_shim/ossl_shim \
+  --rootdir $BASE_DIR/../boringssl/ssl/test/runner/ \
+  --test-cases $BASE_DIR/$CASE_FILE \
+  --client-writes-first \
+  --force-IPv4
+}
+
+run_ossl_client() {
+  cargo run -- \
+  --client $BASE_DIR/../openssl/test/ossl_shim/ossl_shim \
+  --server $BASE_DIR/../dist/Debug/bin/nss_bogo_shim \
+  --rootdir $BASE_DIR/../boringssl/ssl/test/runner/ \
+  --test-cases $BASE_DIR/$CASE_FILE \
+  --force-IPv4
+}
+
+run_loopback() {
+  cargo run -- \
+  --client $BASE_DIR/../dist/Debug/bin/nss_bogo_shim \
+  --server $BASE_DIR/../dist/Debug/bin/nss_bogo_shim \
+  --rootdir $BASE_DIR/../boringssl/ssl/test/runner/ \
+  --test-cases $BASE_DIR/$CASE_FILE
+}
+
+case "$1" in
+  "boring_server")
+      run_boring_server
+      ;;
+  "boring_client")
+      run_boring_client
+      ;;
+  "ossl_server")
+      run_ossl_server
+      ;;
+  "ossl_client")
+      run_ossl_client
+      ;;
+  "loopback")
+      run_loopback
+      ;;
+  *)
+    echo "command not found"
+    ;;
+esac

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 BASE_DIR=$(cd $(dirname $0); pwd -P)
 CASE_FILE=$2
-export RUST_LOG=debug
+#export RUST_LOG=debug
 
 run_boring_server() {
   cargo run -- \

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-BASE_DIR=$(pwd)
+BASE_DIR=$(cd $(dirname $0); pwd -P)
 CASE_FILE=$2
-#export RUST_LOG=debug
+export RUST_LOG=debug
 
 run_boring_server() {
   cargo run -- \

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -54,6 +54,10 @@ impl Agent {
                 command.arg("-max-version");
                 command.arg(min.to_string());
             }
+            if let Some(ref cipher) = a.ciphers {
+                command.arg("-cipher-list");
+                command.arg(cipher.to_string());
+            }
             if let Some(ref flags) = a.flags {
                 for f in flags {
                     command.arg(f);

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@
 pub struct TestCaseAgent {
     pub min_version: Option<u32>,
     pub max_version: Option<u32>,
+    pub ciphers: Option<String>,
     pub flags: Option<Vec<String>>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 // The config file that corresponds to a test.
-#[derive(RustcDecodable, RustcEncodable)]
-#[derive(Debug)]
+#[derive(RustcDecodable, RustcEncodable, Debug)]
 pub struct TestCaseAgent {
     pub min_version: Option<u32>,
     pub max_version: Option<u32>,
@@ -8,15 +7,13 @@ pub struct TestCaseAgent {
     pub flags: Option<Vec<String>>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
-#[derive(Debug)]
+#[derive(RustcDecodable, RustcEncodable, Debug)]
 // These are parameters which let us run parametrized tests.
 pub struct TestCaseParams {
     pub versions: Option<Vec<i32>>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
-#[derive(Debug)]
+#[derive(RustcDecodable, RustcEncodable, Debug)]
 pub struct TestCase {
     pub name: String,
     pub server_key: Option<String>,
@@ -26,8 +23,7 @@ pub struct TestCase {
     pub server: Option<TestCaseAgent>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
-#[derive(Debug)]
+#[derive(RustcDecodable, RustcEncodable, Debug)]
 pub struct TestCases {
     pub cases: Vec<TestCase>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@
 pub struct TestCaseAgent {
     pub min_version: Option<u32>,
     pub max_version: Option<u32>,
-    pub ciphers: Option<String>,
+    pub cipher: Option<String>,
     pub flags: Option<Vec<String>>,
 }
 

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -1,7 +1,9 @@
-fn flatten_sub(mat: &Vec<Vec<Vec<String>>>,
-               index: usize,
-               so_far: &Vec<String>,
-               output: &mut Vec<Vec<String>>) {
+fn flatten_sub(
+    mat: &Vec<Vec<Vec<String>>>,
+    index: usize,
+    so_far: &Vec<String>,
+    output: &mut Vec<Vec<String>>,
+) {
     if index == mat.len() {
         output.push(so_far.clone());
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,7 @@ fn main() {
     let mut f = File::open(matches.value_of("cases").unwrap()).unwrap();
     let mut s = String::from("");
     f.read_to_string(&mut s).expect("Could not read file to string");
-    let cases: TestCases = json::decode(&s).unwrap();
+    let cases: TestCases = json::decode(&s).expect("Malformed JSON config file.");
 
     let mut results = Results::new();
     for c in cases.cases {

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,10 +138,10 @@ impl Results {
             TestResult::Skipped => self.skipped += 1,
             TestResult::Failed => {
                 println!("\nFAILED: {}\n", Results::case_name(case, index));
-                println!("Client stdout: \n{}", String::from_utf8(c_output.stdout.clone()).unwrap());
-                println!("Client stderr: \n{}", String::from_utf8(c_output.stderr.clone()).unwrap());
-                println!("Server stdout: \n{}", String::from_utf8(s_output.stdout.clone()).unwrap());
-                println!("Server stderr: \n{}", String::from_utf8(s_output.stderr.clone()).unwrap());
+                //println!("Client stdout: \n{}", String::from_utf8(c_output.stdout.clone()).unwrap());
+                println!("Client: \n{}", String::from_utf8(c_output.stderr.clone()).unwrap());
+                //rintln!("Server stdout: \n{}", String::from_utf8(s_output.stdout.clone()).unwrap());
+                println!("Server: \n{}", String::from_utf8(s_output.stderr.clone()).unwrap());
                 self.failed += 1
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,26 @@
 extern crate clap;
 #[macro_use]
 extern crate log;
+extern crate env_logger;
 extern crate mio;
 extern crate mio_extras;
-extern crate env_logger;
 extern crate rustc_serialize;
-use clap::{Arg, App};
-use mio::*;
+use clap::{App, Arg};
 use mio::tcp::Shutdown;
+use mio::*;
 use rustc_serialize::json;
-use std::io::prelude::*;
 use std::fs;
+use std::io::prelude::*;
 use std::process::exit;
 mod agent;
 mod config;
-mod test_result;
 mod flatten;
+mod test_result;
 mod tests;
 use agent::Agent;
-use test_result::TestResult;
-use config::{TestCase, TestCases, TestCaseParams};
+use config::{TestCase, TestCaseParams, TestCases};
 use flatten::flatten;
+use test_result::TestResult;
 
 const CLIENT: Token = mio::Token(0);
 const SERVER: Token = mio::Token(1);
@@ -35,8 +35,11 @@ fn copy_data(poll: &Poll, from: &mut Agent, to: &mut Agent) {
     });
     if size == 0 {
         debug!("End of file on {}", from.name);
-        poll.deregister(&from.socket).expect("Could not deregister socket");
-        to.socket.shutdown(Shutdown::Write).expect("Shutdown failed");
+        poll.deregister(&from.socket)
+            .expect("Could not deregister socket");
+        to.socket
+            .shutdown(Shutdown::Write)
+            .expect("Shutdown failed");
         from.alive = false;
         return;
     }
@@ -121,43 +124,46 @@ impl Results {
         }
     }
 
-    //fn update(&mut self, case: &TestCase, index: Option<u32>, result: &TestResult) {
-    fn update(&mut self,
-              case: &TestCase,
-              index: Option<u32>,
-              c_output: &std::process::Output,
-              s_output: &std::process::Output) {
+    fn update(
+        &mut self,
+        case: &TestCase,
+        index: Option<u32>,
+        raw_result: Result<(std::process::Output, std::process::Output), i32>,
+    ) {
         self.ran += 1;
-        let c_status = TestResult::from_status(c_output.status.code().unwrap_or(-1));
-        let s_status = TestResult::from_status(s_output.status.code().unwrap_or(-1));
-        let result = TestResult::merge(c_status, s_status);
-        info!("{}: {}", result.to_string(), Results::case_name(case, index));
+        let result = match raw_result {
+            Ok((c, s)) => {
+                let c_status = TestResult::from_status(c.status.code().unwrap_or(-1));
+                let s_status = TestResult::from_status(s.status.code().unwrap_or(-1));
+                (TestResult::merge(c_status, s_status), Some(c), Some(s))
+            }
+            Err(e) => (TestResult::from_status(e), None, None),
+        };
+        info!(
+            "{}: {}",
+            result.0.to_string(),
+            Results::case_name(case, index)
+        );
 
         match result {
-            TestResult::OK => self.succeeded += 1,
-            TestResult::Skipped => self.skipped += 1,
-            TestResult::Failed => {
+            (TestResult::OK, _, _) => self.succeeded += 1,
+            (TestResult::Skipped, _, _) => self.skipped += 1,
+            (TestResult::Failed, client, server) => {
                 println!("\nFAILED: {}\n", Results::case_name(case, index));
-                //println!("Client stdout: \n{}", String::from_utf8(c_output.stdout.clone()).unwrap());
-                println!("Client: \n{}", String::from_utf8(c_output.stderr.clone()).unwrap());
-                //rintln!("Server stdout: \n{}", String::from_utf8(s_output.stdout.clone()).unwrap());
-                println!("Server: \n{}", String::from_utf8(s_output.stderr.clone()).unwrap());
-                self.failed += 1
-            }
-        }
-    }
-    fn update_simple(&mut self,
-                     case: &TestCase,
-                     index: Option<u32>,
-                     result: &TestResult) {
-        self.ran += 1;
-        info!("{}: {}", result.to_string(), Results::case_name(case, index));
-
-        match *result {
-            TestResult::OK => self.succeeded += 1,
-            TestResult::Skipped => self.skipped += 1,
-            TestResult::Failed => {
-                println!("\nFAILED: {}\n", Results::case_name(case, index));
+                //Stdout would also be available for printing at this point, in case it turns out
+                //to be informative, which was never the case so far.
+                match client {
+                    Some(c) => {
+                        println!("Client: \n{}", String::from_utf8(c.stderr.clone()).unwrap())
+                    }
+                    None => {}
+                };
+                match server {
+                    Some(s) => {
+                        println!("Server: \n{}", String::from_utf8(s.stderr.clone()).unwrap())
+                    }
+                    None => {}
+                };
                 self.failed += 1
             }
         }
@@ -205,24 +211,24 @@ fn run_test_case_meta(results: &mut Results, config: &TestConfig, case: &TestCas
     }
 }
 
-fn run_test_case(results: &mut Results,
-                 config: &TestConfig,
-                 case: &TestCase,
-                 index: Option<u32>,
-                 extra_client_args: &Vec<String>,
-                 extra_server_args: &Vec<String>) {
-
-    match run_test_case_inner(config, case, extra_client_args, extra_server_args) {
-        Ok((c, s)) => results.update(case, index, &c, &s),
-        Err(e) => results.update_simple(case, index, &TestResult::from_status(e))
-    }
+fn run_test_case(
+    results: &mut Results,
+    config: &TestConfig,
+    case: &TestCase,
+    index: Option<u32>,
+    extra_client_args: &Vec<String>,
+    extra_server_args: &Vec<String>,
+) {
+    let res = run_test_case_inner(config, case, extra_client_args, extra_server_args);
+    results.update(case, index, res);
 }
 
-fn run_test_case_inner(config: &TestConfig,
-                       case: &TestCase,
-                       extra_client_args: &Vec<String>,
-                       extra_server_args: &Vec<String>)
-                       -> Result<(std::process::Output, std::process::Output), i32> {
+fn run_test_case_inner(
+    config: &TestConfig,
+    case: &TestCase,
+    extra_client_args: &Vec<String>,
+    extra_server_args: &Vec<String>,
+) -> Result<(std::process::Output, std::process::Output), i32> {
     // Create the server and client args
     let mut server_args = extra_server_args.clone();
     let mut client_args = extra_client_args.clone();
@@ -241,20 +247,34 @@ fn run_test_case_inner(config: &TestConfig,
     // Only nss_bogo_shim can do -write-then-read.
     // bssl_shim and ossl_shim can only be used in the passive role.
     match config.client_writes_first {
-        true => {client_args.push(String::from("-write-then-read"));},
-        false => {server_args.push(String::from("-write-then-read"));},
+        true => {
+            client_args.push(String::from("-write-then-read"));
+        }
+        false => {
+            server_args.push(String::from("-write-then-read"));
+        }
     }
 
-    let mut server = match Agent::new("server", &config.server_shim,
-            &case.server, server_args, config.force_ipv4) {
+    let mut server = match Agent::new(
+        "server",
+        &config.server_shim,
+        &case.server,
+        server_args,
+        config.force_ipv4,
+    ) {
         Ok(a) => a,
         Err(e) => {
             return Err(e);
         }
     };
 
-    let mut client = match Agent::new("client", &config.client_shim,
-            &case.client, client_args, config.force_ipv4) {
+    let mut client = match Agent::new(
+        "client",
+        &config.client_shim,
+        &case.client,
+        client_args,
+        config.force_ipv4,
+    ) {
         Ok(a) => a,
         Err(e) => {
             return Err(e);
@@ -272,36 +292,48 @@ fn main() {
 
     let matches = App::new("TLS interop tests")
         .version("0.0")
-        .arg(Arg::with_name("client")
-            .long("client")
-            .help("The shim to use as the client")
-            .takes_value(true)
-            .required(true))
-        .arg(Arg::with_name("server")
-            .long("server")
-            .help("The shim to use as the server")
-            .takes_value(true)
-            .required(true))
-        .arg(Arg::with_name("rootdir")
-            .long("rootdir")
-            .help("The path where the working files are")
-            .takes_value(true)
-            .required(true))
-        .arg(Arg::with_name("cases")
-            .long("test-cases")
-            .help("The test cases file to run")
-            .takes_value(true)
-            .required(true))
-        .arg(Arg::with_name("client-writes-first")
-            .long("client-writes-first")
-            .help("Client writes after handshake instead of server")
-            .takes_value(false)
-            .required(false))
-        .arg(Arg::with_name("force-IPv4")
-            .long("force-IPv4")
-            .help("Forces IPv4 Sockets even if IPv6 is available")
-            .takes_value(false)
-            .required(false))
+        .arg(
+            Arg::with_name("client")
+                .long("client")
+                .help("The shim to use as the client")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("server")
+                .long("server")
+                .help("The shim to use as the server")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("rootdir")
+                .long("rootdir")
+                .help("The path where the working files are")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("cases")
+                .long("test-cases")
+                .help("The test cases file to run")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("client-writes-first")
+                .long("client-writes-first")
+                .help("Client writes after handshake instead of server")
+                .takes_value(false)
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("force-IPv4")
+                .long("force-IPv4")
+                .help("Forces IPv4 Sockets even if IPv6 is available")
+                .takes_value(false)
+                .required(false),
+        )
         .get_matches();
 
     let config = TestConfig {
@@ -314,7 +346,8 @@ fn main() {
 
     let mut f = fs::File::open(matches.value_of("cases").unwrap()).unwrap();
     let mut s = String::from("");
-    f.read_to_string(&mut s).expect("Could not read file to string");
+    f.read_to_string(&mut s)
+        .expect("Could not read file to string");
     let cases: TestCases = json::decode(&s).expect("Malformed JSON config file.");
 
     let mut results = Results::new();
@@ -323,11 +356,10 @@ fn main() {
         run_test_case_meta(&mut results, &config, &c);
     }
 
-    println!("Tests {}; Succeeded {}; Skipped {}, Failed {}",
-             results.ran,
-             results.succeeded,
-             results.skipped,
-             results.failed);
+    println!(
+        "Tests {}; Succeeded {}; Skipped {}, Failed {}",
+        results.ran, results.succeeded, results.skipped, results.failed
+    );
 
     if results.failed != 0 {
         exit(1);

--- a/src/test_result.rs
+++ b/src/test_result.rs
@@ -34,7 +34,7 @@ impl Display for TestResult {
         match *self {
             TestResult::OK => write!(f, "SUCCEEDED"),
             TestResult::Skipped => write!(f, "SKIPPED"),
-            TestResult::Failed => write!(f, "FAILED")
+            TestResult::Failed => write!(f, "FAILED"),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -86,6 +86,7 @@ fn inner_test_simple(conf_type: ConfigType) {
     run_test_case_meta(&mut results, &config, &c);
 
     assert_eq!(results.failed, 0);
+    cleanup_logfiles();
 }
 
 #[cfg(test)]
@@ -94,7 +95,7 @@ fn inner_test_all_cases(conf_type: ConfigType) {
 
     let mut f = File::open("cases.json").unwrap();
     let mut s = String::from("");
-    f.read_to_string(&mut s).expect("Could not read file to string");
+    f.read_to_string(&mut s).expect("Could not read config file.");
     let cases: TestCases = json::decode(&s).unwrap();
 
     let mut results = Results::new();
@@ -102,6 +103,7 @@ fn inner_test_all_cases(conf_type: ConfigType) {
         run_test_case_meta(&mut results, &config, &c);
     }
     assert_eq!(results.failed, 0);
+    cleanup_logfiles();
 }
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -86,14 +86,13 @@ fn inner_test_simple(conf_type: ConfigType) {
     run_test_case_meta(&mut results, &config, &c);
 
     assert_eq!(results.failed, 0);
-    cleanup_logfiles();
 }
 
 #[cfg(test)]
 fn inner_test_all_cases(conf_type: ConfigType) {
     let config = prepare_config(conf_type);
 
-    let mut f = File::open("cases.json").unwrap();
+    let mut f = fs::File::open("cases.json").unwrap();
     let mut s = String::from("");
     f.read_to_string(&mut s).expect("Could not read config file.");
     let cases: TestCases = json::decode(&s).unwrap();
@@ -103,7 +102,6 @@ fn inner_test_all_cases(conf_type: ConfigType) {
         run_test_case_meta(&mut results, &config, &c);
     }
     assert_eq!(results.failed, 0);
-    cleanup_logfiles();
 }
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,7 +53,7 @@ fn nss_server_vs_ossl_client_simple() {
 
 #[test]
 fn nss_loopback_all_test_cases() {
-    inner_test_all_cases(ConfigType::BsslClient)
+    inner_test_all_cases(ConfigType::NssLoopback)
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 use super::*;
 #[cfg(test)]
-use std::path::Path;
-#[cfg(test)]
 use std::env;
+#[cfg(test)]
+use std::path::Path;
 
 // Test the flattener
 #[test]
@@ -44,7 +44,6 @@ fn nss_client_vs_ossl_server_simple() {
 fn nss_server_vs_boring_client_simple() {
     inner_test_simple(ConfigType::BsslClient);
 }
-
 
 #[test]
 fn nss_server_vs_ossl_client_simple() {
@@ -94,7 +93,8 @@ fn inner_test_all_cases(conf_type: ConfigType) {
 
     let mut f = fs::File::open("cases.json").unwrap();
     let mut s = String::from("");
-    f.read_to_string(&mut s).expect("Could not read config file.");
+    f.read_to_string(&mut s)
+        .expect("Could not read config file.");
     let cases: TestCases = json::decode(&s).unwrap();
 
     let mut results = Results::new();
@@ -122,7 +122,7 @@ enum ConfigType {
     BsslServer,
     BsslClient,
     OsslServer,
-    OsslClient
+    OsslClient,
 }
 
 #[cfg(test)]
@@ -133,16 +133,23 @@ fn prepare_config(conf_type: ConfigType) -> TestConfig {
     let boring_runner_path = &dirs[2];
     let ossl_shim_path = &dirs[3];
 
-    assert!(Path::new(nss_shim_path).exists(),
-            "nss_bogo_shim not found at {}", nss_shim_path);
+    assert!(
+        Path::new(nss_shim_path).exists(),
+        "nss_bogo_shim not found at {}",
+        nss_shim_path
+    );
     match conf_type {
-        ConfigType::NssLoopback => {},
-        ConfigType::BsslServer | ConfigType::BsslClient =>
-            assert!(Path::new(boring_shim_path).exists(),
-            "bssl_shim not found at {}", boring_shim_path),
-        ConfigType::OsslServer | ConfigType::OsslClient =>
-            assert!(Path::new(ossl_shim_path).exists(),
-            "ossl_shim not found at {}", ossl_shim_path),
+        ConfigType::NssLoopback => {}
+        ConfigType::BsslServer | ConfigType::BsslClient => assert!(
+            Path::new(boring_shim_path).exists(),
+            "bssl_shim not found at {}",
+            boring_shim_path
+        ),
+        ConfigType::OsslServer | ConfigType::OsslClient => assert!(
+            Path::new(ossl_shim_path).exists(),
+            "ossl_shim not found at {}",
+            ossl_shim_path
+        ),
     }
 
     TestConfig {
@@ -150,7 +157,6 @@ fn prepare_config(conf_type: ConfigType) -> TestConfig {
             ConfigType::BsslClient => boring_shim_path.clone(),
             ConfigType::OsslClient => ossl_shim_path.clone(),
             _ => nss_shim_path.clone(),
-
         },
         server_shim: match conf_type {
             ConfigType::BsslServer => boring_shim_path.clone(),
@@ -166,7 +172,7 @@ fn prepare_config(conf_type: ConfigType) -> TestConfig {
         force_ipv4: match conf_type {
             ConfigType::OsslServer | ConfigType::OsslClient => true,
             _ => false,
-        }
+        },
     }
 }
 
@@ -189,5 +195,10 @@ fn get_shim_paths() -> Vec<String> {
         None => String::from("../openssl/test/ossl_shim/ossl_shim"),
     };
 
-    vec![nss_shim_path, boring_shim_path, boring_runner_path, ossl_shim_path]
+    vec![
+        nss_shim_path,
+        boring_shim_path,
+        boring_runner_path,
+        ossl_shim_path,
+    ]
 }

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -15,6 +15,7 @@ cd nss
 cd $ROOT_DIR
 git clone https://github.com/google/boringssl.git
 cd boringssl
+git checkout -q 9af1edbe2201e6c6d58e5e484bf56281d8c751d9
 mkdir build
 cd build
 cmake ..
@@ -22,6 +23,7 @@ make -j$(nproc)
 cd $ROOT_DIR
 git clone -q https://github.com/openssl/openssl.git
 cd openssl
+git checkout -q 9e6a32025e6e69949ad3e53a29a0b85f61f30b85
 ./config enable-external-tests
 make -j$(nproc)
 make install


### PR DESCRIPTION
This is non-finished version of the patch to implement cipher tests.
To make this work with nss, a small patch to nss_bogo_shim is required. 
A subset of cipher tests that is already passing is included in cases.json. 
A full list of cipher tests, many of them still failing, is included in all_cipher_cases.json.
run.sh makes it easier to run tests in a certain configuration, producing more informative output than using cargo test. 
example:
   run.sh loopback all_cipher_cases.json


