### PR TITLE
Fix intermittent timeouts

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -171,16 +171,11 @@ impl Agent {
         poll.register(&self.child, STATUS, Ready::readable(), PollOpt::level())
             .unwrap();
         let mut events = Events::with_capacity(1);
-        debug!("Created events. Polling...");
-        let poll_res = poll.poll(&mut events, Some(Duration::new(30, 0))).unwrap();
-        debug!("Poll successful or timed out with {:?}. Trying to receive output...", poll_res);
-        let output = self.child.try_recv().unwrap();
-        debug!("Output is: {:?}", output);
+        poll.poll(&mut events, Some(Duration::new(5, 0))).unwrap();
+        debug!("Poll successful or timed out. Trying to receive output...");
+        let output = self.child.try_recv().expect("Failed to receive output from subthread.");
         let code = output.status.code().unwrap_or(-1);
         debug!("Exit status for {} = {}", self.name, code);
-        if poll_res != 1 {
-            thread::sleep(Duration::new(30, 0));
-        }
         output.clone()
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -171,6 +171,9 @@ impl Agent {
         poll.register(&self.child, STATUS, Ready::readable(), PollOpt::level())
             .unwrap();
         let mut events = Events::with_capacity(1);
+        // There's an (arbitrary) 5 second timeout for polling, because this poll seemed to cause
+        // indefinite blocking of the main thread in rare cases, even when there was an event
+        // available on the channel.
         poll.poll(&mut events, Some(Duration::new(5, 0))).unwrap();
         debug!("Poll successful or timed out. Trying to receive output...");
         let output = self.child.try_recv().expect("Failed to receive output from subthread.");


### PR DESCRIPTION
This probably fixes the problem of intermittent timeouts of the interop tests. 
It's hard to prove that it actually fixes the issue, but it is very likely and the tests have never timed out so far with this fix. 